### PR TITLE
Upstream update

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -63,7 +63,7 @@ def get_builders():
         make_builder('windows-vc14-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'NMake Makefiles JOM', 'jom', paths.vc14x64path, paths.vc14x64include, paths.vc14x64lib, paths.vc14x64libpath),
         make_builder('debian-gcc-64', ['master-debian-64', 'binary1248-debian-64'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
         make_builder('freebsd-gcc-64', ['zsbzsb-freebsd-64', 'binary1248-freebsd-64'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
-        make_builder('osx-clang-universal', ['hiura-osx'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
+        make_builder('osx-clang-el-capitan', ['hiura-osx'], 'tmp', 'Unix Makefiles', 'make', '', '', '', ''),
         make_builder('windows-gcc-492-tdm-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm32path, '', '', ''),
         make_builder('windows-gcc-492-tdm-64', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc492tdm64path, '', '', ''),
         make_builder('windows-gcc-530-mingw-32', ['master-windows', 'expl0it3r-windows'], 'tmp', 'MinGW Makefiles', 'mingw32-make', paths.gcc530mingw32path, '', '', ''),

--- a/buildfactories.py
+++ b/buildfactories.py
@@ -1,4 +1,4 @@
-def get_cmake_step(link, type, frameworks = 'no'):
+def get_cmake_step(link, type, osxExtra = []):
     from buildbot.process.properties import Interpolate
     from buildbot.steps.shell import ShellCommand
     from buildbot.status.results import SKIPPED
@@ -20,21 +20,26 @@ def get_cmake_step(link, type, frameworks = 'no'):
     build_frameworks = ''
     suffix = ''
 
-    if frameworks == 'frameworks':
+    if 'frameworks' in osxExtra:
         build_frameworks += '-DSFML_BUILD_FRAMEWORKS=TRUE'
         suffix = [link, type, 'frameworks'];
     else:
         build_frameworks += '-DSFML_BUILD_FRAMEWORKS=FALSE'
         suffix = [link, type];
 
+    if 'oldSDK' in osxExtra:
+        build_sdk += '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.7'
+        build_sdk += '-DCMAKE_OSX_SYSROOT=/Developer/SDKs/MacOSX10.7.sdk'
+        suffix.append('10.7')
+
     return ShellCommand(
         name = 'cmake',
         description = ['configuring'],
         descriptionSuffix = suffix,
         descriptionDone = ['configure'],
-        doStepIf = lambda step : (('frameworks' not in frameworks) or ('osx' in step.build.getProperty('buildername'))),
+        doStepIf = lambda step : ((not osxExtra) or ('osx' in step.build.getProperty('buildername')))) and (link != 'static' or not ('osx' in step.build.getProperty('buildername')))
         hideStepIf = lambda results, step : results == SKIPPED,
-        command = ['cmake', '-G', Interpolate('%(prop:generator)s'), '-DSFML_BUILD_EXAMPLES=TRUE', Interpolate('-DCMAKE_INSTALL_PREFIX=%(prop:workdir)s/install'), Interpolate('-DCMAKE_INSTALL_FRAMEWORK_PREFIX=%(prop:workdir)s/install/Library/Frameworks'), build_type, shared_libs, build_frameworks, '.'],
+        command = ['cmake', '-G', Interpolate('%(prop:generator)s'), '-DSFML_BUILD_EXAMPLES=TRUE', Interpolate('-DCMAKE_INSTALL_PREFIX=%(prop:workdir)s/install'), Interpolate('-DCMAKE_INSTALL_FRAMEWORK_PREFIX=%(prop:workdir)s/install/Library/Frameworks'), build_type, shared_libs, build_frameworks, build_sdk, '.'],
         env = {
             'PATH' : Interpolate('%(prop:toolchain_path)s%(prop:PATH)s'),
             'INCLUDE' : Interpolate('%(prop:vc_include)s'),
@@ -46,23 +51,26 @@ def get_cmake_step(link, type, frameworks = 'no'):
         logEnviron = False
     )
 
-def get_build_step(link, type, frameworks = 'no'):
+def get_build_step(link, type, osxExtra = []):
     from buildbot.process.properties import Interpolate
     from buildbot.steps.shell import Compile
     from buildbot.status.results import SKIPPED
 
     suffix = ''
 
-    if frameworks == 'frameworks':
+    if 'frameworks' in osxExtra:
         suffix = [link, type, 'frameworks'];
     else:
         suffix = [link, type];
+
+    if 'oldSDK' in osxExtra:
+        suffix.append('10.7')
 
     return Compile(
         description = ['building'],
         descriptionSuffix = suffix,
         descriptionDone = ['build'],
-        doStepIf = lambda step : (('frameworks' not in frameworks) or ('osx' in step.build.getProperty('buildername'))),
+        doStepIf = lambda step : ((not osxExtra) or ('osx' in step.build.getProperty('buildername')))) and (link != 'static' or not ('osx' in step.build.getProperty('buildername')))
         hideStepIf = lambda results, step : results == SKIPPED,
         command = [Interpolate('%(prop:maker)s'), '-j', Interpolate('%(prop:parallel)s'), 'install'],
         env = {
@@ -108,6 +116,7 @@ def get_build_factory():
             },
             logEnviron = False
         ),
+        get_cmake_step('dynamic', 'debug', ['oldSDK']), # do it first so that files are overriden by other steps
         get_cmake_step('dynamic', 'debug'),
         get_build_step('dynamic', 'debug'),
         get_cmake_step('static', 'debug'),
@@ -116,8 +125,8 @@ def get_build_factory():
         get_build_step('dynamic', 'release'),
         get_cmake_step('static', 'release'),
         get_build_step('static', 'release'),
-        get_cmake_step('dynamic', 'release', 'frameworks'),
-        get_build_step('dynamic', 'release', 'frameworks'),
+        get_cmake_step('dynamic', 'release', ['frameworks']),
+        get_build_step('dynamic', 'release', ['frameworks']),
         DirectoryUpload(
             description = ['uploading'],
             descriptionSuffix = ['artifact'],


### PR DESCRIPTION
- Update buildfactories for OS X
  - static build are now skipped on OS X
  - a new step is added to compile against an older SDK
- Update OS X builder name
